### PR TITLE
Fix acquire for timeout case

### DIFF
--- a/redis_semaphore/__init__.py
+++ b/redis_semaphore/__init__.py
@@ -52,7 +52,7 @@ class Semaphore(object):
         if self.blocking:
             pair = self.client.blpop(self.available_key, timeout)
             if pair is None:
-                return None
+                raise NotAvailable
             token = pair[1]
         else:
             token = self.client.lpop(self.available_key)
@@ -74,7 +74,7 @@ class Semaphore(object):
             return False
         self.client.expire(self.check_release_locks_key, expires)
         try:
-            for token, looked_at in self.client.hgetall(self.grabbed_key).iteritems():
+            for token, looked_at in self.client.hgetall(self.grabbed_key).items():
                 timed_out_at = float(looked_at) + self.stale_client_timeout
                 if timed_out_at < self.current_time:
                     self.signal(token)

--- a/tests/test_semaphore.py
+++ b/tests/test_semaphore.py
@@ -11,7 +11,7 @@ from redis_semaphore import Semaphore
 class SimpleTestCase(TestCase):
 
     def setUp(self):
-        redis_host = os.environ.get('TEST_REDIS_HOST', 'localhost')
+        redis_host = os.environ.get('TEST_REDIS_HOST') or 'localhost'
         self.client = StrictRedis(host=redis_host)
         self.s_count = 2
         self.sem1 = Semaphore(

--- a/tests/test_semaphore.py
+++ b/tests/test_semaphore.py
@@ -1,6 +1,9 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import
+
+import os
 from unittest import TestCase
+
 from redis import StrictRedis
 from redis_semaphore import Semaphore
 
@@ -8,7 +11,8 @@ from redis_semaphore import Semaphore
 class SimpleTestCase(TestCase):
 
     def setUp(self):
-        self.client = StrictRedis()
+        redis_host = os.environ.get('TEST_REDIS_HOST', 'localhost')
+        self.client = StrictRedis(host=redis_host)
         self.s_count = 2
         self.sem1 = Semaphore(
             client=self.client,
@@ -64,6 +68,13 @@ class SimpleTestCase(TestCase):
         with self.assertRaises(NotAvailable):
             with self.sem3:
                 assert False, 'should never reach here'
+
+    def test_acquire_with_timeout(self):
+        from redis_semaphore import NotAvailable
+        for _ in range(self.s_count):
+            self.sem1.acquire()
+        with self.assertRaises(NotAvailable):
+            self.sem1.acquire(timeout=1)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,5 @@ envlist = py27, py33, py34, py35
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt
 commands = nosetests
+setenv =
+  TEST_REDIS_HOST = {env:TEST_REDIS_HOST:}


### PR DESCRIPTION
+ fix for `iteritems` -> `items` (for python 3.x)
+ improved testing

In general if you do `lock.acquire(timeout=X)` you should get an exception, so you don't have to additionally check if returned value is `None`.