### PR TITLE
Update README.md (force unlock in case of fire)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,3 +56,14 @@ Examples
 
     if __name__ == '__main__':
         main()
+
+Force unlock
+-------------
+
+If the process that has the lock is killed, the semaphore will stay locked. To manually release it:
+
+::
+    
+    semaphore = Semaphore(Redis(),count=1,namespace='example')
+    token = semaphore.get_namespaced_key('example')
+    semaphore.signal(token)


### PR DESCRIPTION
Just a little documentation on how to manually unlock a locked semaphore when the process that had the lock was killed, or that server went down or something happened.