### PR TITLE
fix: check_release_locks_key not been set expired time

### DIFF
--- a/redis_semaphore/__init__.py
+++ b/redis_semaphore/__init__.py
@@ -70,10 +70,11 @@ class Semaphore(object):
         return token
 
     def release_stale_locks(self, expires=10):
-        token = self.client.getset(self.check_release_locks_key, self.exists_val)
+        token = self.client.get(self.check_release_locks_key)
         if token:
             return False
-        self.client.expire(self.check_release_locks_key, expires)
+        
+        token = self.client.set(self.check_release_locks_key, self.exists_val, ex=expires)
         try:
             for token, looked_at in dict_items(self.client.hgetall(self.grabbed_key)):
                 timed_out_at = float(looked_at) + self.stale_client_timeout


### PR DESCRIPTION
```
        token = self.client.getset(self.check_release_locks_key, self.exists_val)
        if token:
            return False
        self.client.expire(self.check_release_locks_key, expires)
```

when self.client.getset() run success, but process suddenly exit for some reason, eg. kill by master process, or machine shutdown. 
the self.check_release_locks_key will never been set expired time.